### PR TITLE
Add 'zcn' library to list "Other"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ This is a collection of **awesome resources** about [Zod](https://github.com/col
 - [`zod-localstorage`](https://github.com/bigbeno37/zod-localstorage) - A Typescript library to allow typesafe access to localstorage using schema validation from Zod.
 - [`zod-formik-adapter`](https://github.com/robertLichtnow/zod-formik-adapter) - Formik adapter for Zod.
 - [`@felte/validator-zod`](https://github.com/pablo-abc/felte/tree/main/packages/validator-zod) - Handle validation with Zod in Felte.
+- [`zcn`](https://github.com/wesleydmscn/zcn/) - A set of ready-made schemas extended for Zod. (`z.otp`, `z.username`, `z.port`, `z.nodeEnv` and more...)
 
 ## Projects Using Zod
 - [`prisma-trpc-generator`](https://github.com/omar-dulaimi/prisma-trpc-generator) - Prisma 2+ generator to emit fully implemented tRPC routers.


### PR DESCRIPTION
Developed to extend Zod's standard validations, zcn integrates seamlessly into your projects in the same way you would use Zod. 🎉

## Example using ready-made schema `z.otp()`
```ts
import { z } from "zcn";

const ConfirmSecutityCodeSchema = z.object({
  code: z.otp({ min: 6, error: "Invalid OTP" }),
});
```

## Inferring types
```ts
import { z, type ZTypes } from "zcn";

const Customer = z.object({
  name: z.string().nonempty(),
  cpf: z.cpf(),
  telephone: z.telephone(),
});

type Customer = ZTypes.infer<typeof Customer>;

const customer: Customer = {
  name: "Wesley Damasceno",
  cpf: "00000000000",
  telephone: "99999999999"
};
```