### PR TITLE
Add json-to-ts to Convertors and Generators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ This is a collection of **awesome resources** about [Zod](https://github.com/col
 - [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema) - Convert your Zod schemas into JSON Schemas.
 - [`json-schema-to-zod`](https://github.com/StefanTerdell/json-schema-to-zod) - Convert your JSON Schemas into Zod schemas.
 - [`json-to-zod`](https://github.com/rsinohara/json-to-zod) - Convert JSON objects into Zod schemas.
+- [`json-to-ts`](https://github.com/SolvoHQ/json-to-ts) - Free hosted converter ([json-to-ts-app.netlify.app](https://json-to-ts-app.netlify.app/)) that turns a pasted JSON sample into a Zod schema (also TypeScript interfaces and Valibot schemas) — no install, runs entirely in the browser.
 - [`zod-prisma`](https://github.com/CarterGrimmeisen/zod-prisma) - Generate Zod schemas from your Prisma schema.
 - [`Supervillain`](https://github.com/Southclaws/supervillain) - Generate Zod schemas from your Go structs.
 - [`@anatine/zod-openapi`](https://github.com/anatine/zod-plugins/tree/main/libs/zod-openapi) - Converts a Zod schema to an OpenAPI v3.x `SchemaObject`.


### PR DESCRIPTION
Adds [json-to-ts](https://json-to-ts-app.netlify.app/) to the **Convertors and Generators** section, immediately after the existing `json-to-zod` entry.

## What it is

A free, hosted, in-browser converter that turns a pasted JSON sample into:
- a Zod schema (the primary output),
- a TypeScript interface,
- a Valibot schema.

Runs entirely client-side, no signup, MIT-licensed source at [SolvoHQ/json-to-ts](https://github.com/SolvoHQ/json-to-ts).

## Why it fits this section

Direct sibling to `json-to-zod` (CLI utility): same input → Zod output, but a hosted UI rather than an npm install. The other entries in this section also include browser-only tools (e.g. `zod-to-json-schema`'s playground), so format precedent exists.

## Format

Followed the existing `[`name`](repo)` - description style. One line, lowercase backticked name, sentence-case description.