### PR TITLE
Add jsontosdk to Convertors and Generators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ This is a collection of **awesome resources** about [Zod](https://github.com/col
 - [`atlas2ts`](https://www.npmjs.com/package/atlas2ts) - Generates typescript interfaces or zod typespecs from atlas DDL specification.
 - [`kanel-zod`](https://www.npmjs.com/package/kanel-zod) - Generates Zod schemas from a live Postgres database.
 - [`zenko`](https://www.npmjs.com/package/zenko) - Generates Zod schemas and helper functions from an OpenAPI v3.x spec
+- [`jsontosdk`](https://github.com/SolvoHQ/jsontosdk) - Paste a JSON sample and generate a Zod schema alongside a typed TypeScript interface and fetch helper.
 
 ## CLIs
 


### PR DESCRIPTION
Adds [`jsontosdk`](https://github.com/SolvoHQ/jsontosdk) to the **Convertors and Generators** section.

It's a JSON-to-Zod tool: paste a JSON sample (e.g. an API response) and it emits a Zod schema, a typed TypeScript interface, and a fetch helper in one go. Closest peer in the list is `json-to-zod` — same input direction, but jsontosdk also emits the TS interface and the fetch wrapper, which is the missing 80% for "wire up a third-party API quickly."

Live at https://jsontosdk.vercel.app, MIT-licensed.