### PR TITLE
Add arkenv to Other

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ This is a collection of **awesome resources** about [Zod](https://github.com/col
 - [`zod-formik-adapter`](https://github.com/robertLichtnow/zod-formik-adapter) - Formik adapter for Zod.
 - [`@felte/validator-zod`](https://github.com/pablo-abc/felte/tree/main/packages/validator-zod) - Handle validation with Zod in Felte.
 - [`zcn`](https://github.com/wesleydmscn/zcn/) - A set of ready-made schemas extended for Zod. (`z.otp`, `z.username`, `z.port`, `z.nodeEnv` and more...)
+- [`arkenv`](https://github.com/yamcodes/arkenv) - Environment variable validation from editor to runtime, powered by Zod or any Standard Schema library.
 
 ## Projects Using Zod
 - [`prisma-trpc-generator`](https://github.com/omar-dulaimi/prisma-trpc-generator) - Prisma 2+ generator to emit fully implemented tRPC routers.


### PR DESCRIPTION
Adds [`arkenv`](https://github.com/yamcodes/arkenv) to the Other section.

ArkEnv validates environment variables from editor to runtime, and accepts Zod schemas (or any Standard Schema library) for validation. Zod 4 is supported and tested in CI. Docs: https://arkenv.js.org

Made with [Cursor](https://cursor.com)